### PR TITLE
Add signed DuckFlight extension repository tooling

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -39,3 +39,8 @@ jobs:
           uv run --with ruff ruff check scripts/duckflight_auth.py test/test_duckflight_auth.py
           uv run --with ruff ruff format --check scripts/duckflight_auth.py test/test_duckflight_auth.py
           uv run test/test_duckflight_auth.py
+      - name: Extension repository signing tests
+        run: |
+          uv run --with ruff ruff check scripts/extension_repository.py test/test_extension_repository.py test/test_alpha_duckflight.py
+          uv run --with ruff ruff format --check scripts/extension_repository.py test/test_extension_repository.py test/test_alpha_duckflight.py
+          uv run test/test_extension_repository.py

--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,6 @@ duckdb_unittest_tempdir/
 __pycache__/
 *.py[cod]
 .ruff_cache/
+.wrangler/
 /users.toml
 /duckflight.toml

--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ load duckflight;
 DuckDB downloads the build matching your DuckDB version and platform. DuckFlight currently supports
 Linux and macOS on amd64 and arm64.
 
+An independently signed repository for DuckDB 2.0 alpha is available at
+`https://extensions.sidequery.dev`. The tested installation target is
+`v2.0.0-alpha41489` on macOS arm64. See
+[signed repository installation and release instructions](docs/EXTENSION_REPOSITORY.md).
+
 <details>
 <summary>Load an unsigned artifact from GitHub Releases</summary>
 

--- a/docs/EXTENSION_REPOSITORY.md
+++ b/docs/EXTENSION_REPOSITORY.md
@@ -1,0 +1,194 @@
+# Sidequery's signed extension repository
+
+The public repository is `https://extensions.sidequery.dev`, backed directly by the
+`sidequery-duckdb-extensions` R2 bucket in Sidequery Production. The R2 custom domain
+requires TLS 1.2 or newer. A Worker and DuckDB's community signing service are not
+needed.
+
+## Current availability
+
+DuckFlight `0.1.5-alpha` is published for **macOS arm64**, under both
+`v2.0.0-alpha41489` and `v2.0.0-alpha41533`. Use **alpha41489** for a fresh HTTPS
+installation: its matching official `httpfs` is available. At validation time,
+alpha41533's runtime was downloadable but its upstream extension deployment was
+still queued, so automatic `httpfs` installation returned 404. Both native
+runtimes reported source revision `10de957379`.
+
+The rebuilt private core uses modern lambda syntax in its compatibility macros
+and generated catalog views, and recognizes exact trusted legacy definitions.
+The actual bundled core passed authenticated PostgreSQL and Flight SQL client
+checks on both runtimes, with signatures enforced for repository installation.
+Initial `load` took about one to two minutes on the validation host.
+
+Exact official alpha41489 CLI and shared-library artifacts can be retrieved with
+an authenticated GitHub CLI. These endpoints return tar.gz content:
+
+```sh
+gh api repos/duckdb/duckdb/actions/artifacts/10287349741/zip > duckdb-cli-osx-universal.tar.gz
+gh api repos/duckdb/duckdb/actions/artifacts/10287434612/zip > duckdb-shared-libs-osx-universal.tar.gz
+```
+
+The CLI archive SHA-256 is
+`6a8fd6cc2cb62c5c35804bfc76c5313dea7002cec74074850e786c8953f02108`.
+Check `pragma version` after extraction; moving-channel downloads can advance to
+an alpha whose matching core extensions are not yet published.
+
+The existing 1.5.5 Community distribution is unchanged.
+
+## Trust the repository
+
+On a compatible DuckDB alpha runtime:
+
+```sql
+set allow_extension_repositories = 'allowed';
+create extension repository sidequery
+    with prefix 'https://extensions.sidequery.dev';
+
+select repository_name, prefix, key_fingerprints
+from duckdb_extension_repositories()
+where repository_name = 'sidequery';
+```
+
+Compare the returned fingerprint with:
+
+```text
+sha256:3913381c7400db553886bcf98a0f5dddaed632a3502e8cf618d40ecabc4ee24d
+```
+
+DuckDB fetches the PEM public key from
+[`/.well-known/duckdb-extension-repo.json`](https://extensions.sidequery.dev/.well-known/duckdb-extension-repo.json)
+and pins it locally. Keep `allow_unsigned_extensions=false`.
+
+For the published runtime and platform:
+
+```sql
+install duckflight from sidequery;
+load duckflight from sidequery;
+select * from duckflight_core_status();
+```
+
+`loaded` must be `true`. Loading the shim alone does not establish that its core
+or servers work. Always include `from sidequery` when loading from this repository.
+
+## Signing key
+
+The RSA-2048 private key is stored in the **Sidequery** 1Password vault in
+**DuckDB Extension Repository Signing Key**, field `private_key`. The item also
+contains `public_key` and `fingerprint`. The preparation tool uses that item's
+stable 1Password reference by default.
+
+Only public-key metadata belongs in `repository/` and R2. The signing tool reads
+the private key through `op read` into process memory, passes it to OpenSSL through
+stdin, and verifies that it matches the checked-in public key. It never writes the
+private key to an artifact or temporary file. This setup does not copy the key to
+GitHub Actions secrets.
+
+## Prepare and publish an extension
+
+Prerequisites: `uv`, OpenSSL, an authenticated 1Password CLI, and Wrangler
+authenticated to Sidequery Production. Build an artifact with the correct ABI
+metadata and validate it on the exact target runtime before signing.
+
+DuckDB alpha's V2 unstable C API requires a different entrypoint from this shim.
+The verified ABI for this shim is `C_STRUCT` with minimum V1 API
+`v1.5.6`, using the pinned `extension-ci-tools` metadata writer. This API version
+is distinct from the runtime-specific repository directory. Do not rewrite an
+existing unstable artifact's footer to bypass the version check.
+
+```sh
+uv run scripts/extension_repository.py prepare build/alpha/duckflight.duckdb_extension \
+  --output build/repository --version "$DUCKDB_REPOSITORY_VERSION"
+```
+
+Set `DUCKDB_REPOSITORY_VERSION` to the exact directory requested by the target
+runtime, not an assumed release label. Development builds may use a source
+revision. The published directories are `v2.0.0-alpha41489` and
+`v2.0.0-alpha41533`, and the tested platform is `osx_arm64`. The output is:
+
+```text
+build/repository/<runtime-directory>/<platform>/duckflight.duckdb_extension.gz
+```
+
+Preparation preserves ABI metadata, refuses existing signatures and output files,
+uses DuckDB's two-level SHA-256 hash and RSA PKCS#1 v1.5 signature, verifies the
+result, and writes deterministic gzip. It does not upload anything.
+
+Before publication, verify signed install and load with unsigned extensions
+disabled, core initialization, and authenticated PostgreSQL and Flight SQL
+queries. Publish only the tested objects:
+
+```sh
+wrangler whoami
+wrangler r2 object put sidequery-duckdb-extensions/.well-known/duckdb-extension-repo.json \
+  --file repository/.well-known/duckdb-extension-repo.json \
+  --content-type application/json --cache-control 'public, max-age=300' --remote
+
+wrangler r2 object put "sidequery-duckdb-extensions/$DUCKDB_REPOSITORY_VERSION/$DUCKDB_PLATFORM/duckflight.duckdb_extension.gz" \
+  --file "build/repository/$DUCKDB_REPOSITORY_VERSION/$DUCKDB_PLATFORM/duckflight.duckdb_extension.gz" \
+  --content-type application/gzip --cache-control 'public, max-age=300' --remote
+```
+
+The `.gz` object is a compressed download; do not set HTTP `Content-Encoding: gzip`.
+Verify the public HTTPS bytes against the prepared object's SHA-256 after upload.
+
+## Validation and upstream references
+
+```sh
+uv run test/test_extension_repository.py
+
+# Also exercise signature verification in the actual alpha engine:
+DUCKDB_ALPHA_LIBRARY=/path/to/libduckdb.dylib uv run test/test_extension_repository.py
+
+# Real core, authenticated PgWire and Flight SQL clients, isolated temporary trust:
+DUCKDB_ALPHA_LIBRARY=/path/to/libduckdb.dylib \
+  uv run test/test_alpha_duckflight.py --repository https://extensions.sidequery.dev
+
+# Before signing, validate a freshly built local artifact explicitly:
+DUCKDB_ALPHA_LIBRARY=/path/to/libduckdb.dylib \
+  DUCKFLIGHT_ALPHA_EXTENSION=build/alpha/duckflight.duckdb_extension \
+  uv run test/test_alpha_duckflight.py --allow-unsigned
+```
+
+The optional engine test compiles a small native no-op fixture. It proves signed
+installation, loading, persisted trust, and tamper rejection with unsigned
+extensions disabled; it does not test the DuckFlight core. Without the library
+environment variable, that integration test is explicitly skipped.
+
+The real-core client test uses a default 120-second child-process deadline, temporary
+authentication credentials, and ephemeral loopback listeners. It checks core
+initialization, shared host data, PostgreSQL commits/rollbacks and authentication,
+Flight authentication and queries, compatibility macros, and schema discovery.
+Repository mode always requires valid signatures.
+Set `DUCKFLIGHT_ALPHA_TEST_TIMEOUT=240` on a heavily loaded host; the test remains
+bounded. A signed run hit the default deadline under high load, then passed with
+the same artifact when load subsided.
+
+### Published build provenance
+
+The public shim is based on `bb078b8`. The private core is based on
+`d5cb34897b3f679d3f72b039fef2686082c2d409`, with the catalog lambda compatibility
+patch; this preserves the released FFI source and dependency pins. No ABI footer was
+rewritten on an old extension: the shim was rebuilt with the new core and fresh
+metadata was appended with the pinned `extension-ci-tools` writer.
+
+The normalized embedded core SHA-256 is
+`6b714884e95ed4015eecc1bd21af1bd9b55cdee288e5311a61478281bb067a99`.
+The signed gzip artifact SHA-256, identical in both runtime directories, is
+`433d8e30cffde0e0a038bb0c51e35a5919ccab55b1f1562e3c15c4ae9eb50e43`.
+The core links only system libraries; its expected FFI export and absence of
+personal build paths were checked before embedding.
+
+Native builds, signing tests, formatting checks, and actual client checks were
+run. The private full Rust test suite and Docker rebuild were deferred while
+the host had extreme system load; their added regressions are not claimed as run.
+
+- [External extension repositories](https://github.com/duckdb/duckdb/pull/24777)
+- [Pinned alpha extension loader](https://github.com/duckdb/duckdb/blob/10de9573794001c649621013bdd93553b54e00c9/src/main/extension/extension_load.cpp)
+- [Cloudflare R2 custom domains](https://developers.cloudflare.com/r2/buckets/public-buckets/)
+
+The isolated alpha CLI archive used for validation had SHA-256
+`bf702f47e0cbfc4adf638ba8d407245f06bf36f102def1b7bba752f648936bc5`.
+The matching shared-library archive had SHA-256
+`db710aecfaf475dbf871f771ac4a459bca9e28d57727c74ead7315cafd09afb7`.
+Both came from DuckDB's moving `v2.0-cyanoptera` artifact channel, so future downloads
+must be checked for their actual version and revision.

--- a/repository/.well-known/duckdb-extension-repo.json
+++ b/repository/.well-known/duckdb-extension-repo.json
@@ -1,0 +1,5 @@
+{
+  "signature_keys": [
+    "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArbbebNUK3Dtk49hgdMyE\nYCIAXPraokCAU/V2ZCleeZ4rWvLJnfoXo3zNlvDSnb9A3oqCSmutZSxzGkyhktiO\nZO3beFC+GwD6b8GsYReyo5b8JPajeLCTaNv7HcXpxoPbqfemgIPiDJnv81dU/lvB\n8QYkc0zcLl7lM0OvA/lculc7AQEIDG14XxCrkgzf9QM8PgckWQNHzgNZK9I5muvO\nEBLCoEjI+hJ0wW3BCBzwK2fE+2M7Jwbj1G0lyNq2Etao7x2lYHkaFeT2O1lK1Pi+\nYNfvyfcGTaVDogBQ1SHj+WN8KGvXjHymAWjY2QARaHMLcbZuJFUsgIJaP/8oE2Mx\npwIDAQAB\n-----END PUBLIC KEY-----\n"
+  ]
+}

--- a/scripts/extension_repository.py
+++ b/scripts/extension_repository.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""Sign a native DuckFlight extension and prepare its public repository object."""
+
+import argparse
+import gzip
+import hashlib
+import io
+import json
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+DEFAULT_METADATA = (
+    Path(__file__).resolve().parents[1]
+    / "repository/.well-known/duckdb-extension-repo.json"
+)
+DEFAULT_KEY = "op://ja3rm4nzuu3bk5yi3rmumeetga/2eeiayq7xlbjj3y2tmaaqivkbm/private_key"
+CHUNK_SIZE = 1024 * 1024
+SIGNATURE_SIZE = 256
+
+
+def run(arguments, data=None):
+    """Capture subprocess output; never surface private-key inputs or diagnostics."""
+    result = subprocess.run(arguments, input=data, capture_output=True, check=False)
+    if result.returncode:
+        raise ValueError(
+            f"{arguments[0]} {arguments[1]} failed (exit {result.returncode})"
+        )
+    return result.stdout
+
+
+def identifier(value):
+    if not isinstance(value, str) or not re.fullmatch(
+        r"[A-Za-z0-9][A-Za-z0-9_.-]{0,127}", value
+    ):
+        raise ValueError("invalid repository path identifier")
+    return value
+
+
+def metadata(data, version):
+    identifier(version)
+    if len(data) <= 512 or data.startswith(b"\0asm"):
+        raise ValueError("expected a native extension with a 512-byte footer")
+    fields = []
+    for offset in range(len(data) - 512, len(data) - 256, 32):
+        raw = data[offset : offset + 32].rstrip(b"\0")
+        if b"\0" in raw:
+            raise ValueError("invalid metadata padding")
+        try:
+            fields.append(raw.decode("ascii"))
+        except UnicodeDecodeError as error:
+            raise ValueError("invalid metadata encoding") from error
+    magic, platform, target, _extension_version, abi, *reserved = reversed(fields)
+    if magic != "4" or any(reserved):
+        raise ValueError("invalid metadata magic or reserved fields")
+    identifier(platform)
+    identifier(target)
+    if abi not in ("", "CPP", "C_STRUCT", "C_STRUCT_UNSTABLE"):
+        raise ValueError("unsupported extension ABI")
+    if abi == "C_STRUCT":
+        if not re.fullmatch(r"v[12]\.\d+\.\d+", target):
+            raise ValueError("invalid stable C API version")
+    elif target != version:
+        raise ValueError("repository version must match the compiled DuckDB version")
+    return platform
+
+
+def digest(data):
+    # DuckDB extension_load.cpp: ComputeFinalHash, InitializeAncillaryData.
+    chunks = (
+        hashlib.sha256(data[start : start + CHUNK_SIZE]).digest()
+        for start in range(0, len(data), CHUNK_SIZE)
+    )
+    return hashlib.sha256(b"".join(chunks)).digest()
+
+
+def verify(data, public_key):
+    with tempfile.TemporaryDirectory(prefix="duckflight-verify-") as directory:
+        directory = Path(directory)
+        (directory / "public.pem").write_bytes(public_key)
+        (directory / "digest").write_bytes(digest(data[:-SIGNATURE_SIZE]))
+        (directory / "signature").write_bytes(data[-SIGNATURE_SIZE:])
+        run(
+            [
+                "openssl",
+                "pkeyutl",
+                "-verify",
+                "-pubin",
+                "-inkey",
+                str(directory / "public.pem"),
+                "-in",
+                str(directory / "digest"),
+                "-sigfile",
+                str(directory / "signature"),
+                "-pkeyopt",
+                "digest:sha256",
+                "-pkeyopt",
+                "rsa_padding_mode:pkcs1",
+            ]
+        )
+
+
+def sign(data, private_key, public_key):
+    if any(data[-SIGNATURE_SIZE:]):
+        raise ValueError("refusing to replace an existing signature")
+    actual_public = run(["openssl", "pkey", "-pubout", "-outform", "DER"], private_key)
+    expected_public = run(["openssl", "pkey", "-pubin", "-outform", "DER"], public_key)
+    if actual_public != expected_public:
+        raise ValueError("private key does not match repository public key")
+    with tempfile.TemporaryDirectory(prefix="duckflight-sign-") as directory:
+        digest_file = Path(directory) / "digest"
+        digest_file.write_bytes(digest(data[:-SIGNATURE_SIZE]))
+        signature = run(
+            [
+                "openssl",
+                "pkeyutl",
+                "-sign",
+                "-inkey",
+                "/dev/stdin",
+                "-in",
+                str(digest_file),
+                "-pkeyopt",
+                "digest:sha256",
+                "-pkeyopt",
+                "rsa_padding_mode:pkcs1",
+            ],
+            private_key,
+        )
+    if len(signature) != SIGNATURE_SIZE:
+        raise ValueError("signing requires an RSA-2048 key")
+    signed = data[:-SIGNATURE_SIZE] + signature
+    verify(signed, public_key)
+    return signed
+
+
+def prepare(
+    artifact,
+    output,
+    version,
+    public_metadata=DEFAULT_METADATA,
+    key_reference=DEFAULT_KEY,
+):
+    if artifact.name != "duckflight.duckdb_extension":
+        raise ValueError("artifact must be named duckflight.duckdb_extension")
+    data = artifact.read_bytes()
+    platform = metadata(data, version)
+    if any(data[-SIGNATURE_SIZE:]):
+        raise ValueError("refusing to replace an existing signature")
+    document = json.loads(public_metadata.read_text())
+    keys = document.get("signature_keys") if isinstance(document, dict) else None
+    if not isinstance(keys, list) or len(keys) != 1 or not isinstance(keys[0], str):
+        raise ValueError(
+            "repository metadata must contain exactly one public signing key"
+        )
+    if not key_reference.startswith("op://"):
+        raise ValueError("private key must be referenced through 1Password")
+    private_key = run(["op", "read", key_reference])
+    signed = sign(data, private_key, keys[0].encode())
+    destination = output / version / platform / "duckflight.duckdb_extension.gz"
+    compressed = io.BytesIO()
+    with gzip.GzipFile(filename="", mode="wb", fileobj=compressed, mtime=0) as stream:
+        stream.write(signed)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    # Exclusive creation prevents silently replacing an already prepared release.
+    with destination.open("xb") as stream:
+        stream.write(compressed.getvalue())
+    return destination
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+    command = commands.add_parser("prepare")
+    command.add_argument("artifact", type=Path)
+    command.add_argument("--output", type=Path, required=True)
+    command.add_argument(
+        "--version",
+        required=True,
+        help="runtime repository version; never changes artifact metadata",
+    )
+    command.add_argument("--public-metadata", type=Path, default=DEFAULT_METADATA)
+    command.add_argument("--key-reference", default=DEFAULT_KEY)
+    args = parser.parse_args()
+    try:
+        print(
+            prepare(
+                args.artifact,
+                args.output,
+                args.version,
+                args.public_metadata,
+                args.key_reference,
+            )
+        )
+    except (ValueError, OSError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/test_alpha_duckflight.py
+++ b/test/test_alpha_duckflight.py
@@ -1,0 +1,401 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#   "psycopg[binary]==3.3.5",
+#   "adbc-driver-flightsql==1.12.0",
+#   "pyarrow==25.0.1",
+# ]
+# ///
+"""Real DuckFlight alpha regression, isolated in a child with a default 120s deadline.
+
+Set DUCKDB_ALPHA_LIBRARY and DUCKFLIGHT_ALPHA_EXTENSION, then run with uv.
+Unsigned local artifacts additionally require --allow-unsigned. --repository PREFIX
+installs from a signed repository instead and always requires signature validation.
+Unittest discovery skips this integration test when no alpha library is configured.
+DUCKFLIGHT_ALPHA_TEST_TIMEOUT overrides the child deadline on overloaded hosts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ctypes
+import hashlib
+import os
+import secrets
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+
+class DuckDBResult(ctypes.Structure):
+    # Public duckdb.h v1 result layout; values are read through accessor functions.
+    _fields_ = [
+        ("deprecated_column_count", ctypes.c_uint64),
+        ("deprecated_row_count", ctypes.c_uint64),
+        ("deprecated_rows_changed", ctypes.c_uint64),
+        ("deprecated_columns", ctypes.c_void_p),
+        ("deprecated_error_message", ctypes.c_void_p),
+        ("internal_data", ctypes.c_void_p),
+    ]
+
+
+def sql_literal(value: str) -> str:
+    return "'" + value.replace("'", "''") + "'"
+
+
+def require_equal(actual, expected, label):
+    if actual != expected:
+        raise AssertionError(f"{label}: expected {expected!r}, got {actual!r}")
+
+
+class Host:
+    def __init__(self, library: str, directory: Path, unsigned: bool):
+        self.api = ctypes.CDLL(library)
+        pointer = ctypes.c_void_p
+        signatures = {
+            "duckdb_create_config": ([ctypes.POINTER(pointer)], ctypes.c_int),
+            "duckdb_set_config": (
+                [pointer, ctypes.c_char_p, ctypes.c_char_p],
+                ctypes.c_int,
+            ),
+            "duckdb_destroy_config": ([ctypes.POINTER(pointer)], None),
+            "duckdb_open_ext": (
+                [
+                    ctypes.c_char_p,
+                    ctypes.POINTER(pointer),
+                    pointer,
+                    ctypes.POINTER(pointer),
+                ],
+                ctypes.c_int,
+            ),
+            "duckdb_close": ([ctypes.POINTER(pointer)], None),
+            "duckdb_connect": ([pointer, ctypes.POINTER(pointer)], ctypes.c_int),
+            "duckdb_disconnect": ([ctypes.POINTER(pointer)], None),
+            "duckdb_query": (
+                [pointer, ctypes.c_char_p, ctypes.POINTER(DuckDBResult)],
+                ctypes.c_int,
+            ),
+            "duckdb_destroy_result": ([ctypes.POINTER(DuckDBResult)], None),
+            "duckdb_result_error": ([ctypes.POINTER(DuckDBResult)], ctypes.c_char_p),
+            "duckdb_value_varchar": (
+                [ctypes.POINTER(DuckDBResult), ctypes.c_uint64, ctypes.c_uint64],
+                pointer,
+            ),
+            "duckdb_row_count": ([ctypes.POINTER(DuckDBResult)], ctypes.c_uint64),
+            "duckdb_column_count": ([ctypes.POINTER(DuckDBResult)], ctypes.c_uint64),
+            "duckdb_free": ([pointer], None),
+        }
+        for name, (arguments, result) in signatures.items():
+            getattr(self.api, name).argtypes = arguments
+            getattr(self.api, name).restype = result
+        self.database, self.connection = pointer(), pointer()
+        config, error = pointer(), pointer()
+        try:
+            require_equal(
+                self.api.duckdb_create_config(ctypes.byref(config)), 0, "create config"
+            )
+            for name, value in {
+                "extension_repository_directory": str(directory / "trust"),
+                "extension_directories": f"[{sql_literal(str(directory / 'installed'))}]",
+                "allow_unsigned_extensions": str(unsigned).lower(),
+                "allow_extension_repositories": "allowed",
+            }.items():
+                require_equal(
+                    self.api.duckdb_set_config(config, name.encode(), value.encode()),
+                    0,
+                    name,
+                )
+            status = self.api.duckdb_open_ext(
+                None, ctypes.byref(self.database), config, ctypes.byref(error)
+            )
+            if status:
+                raise RuntimeError(
+                    ctypes.string_at(error).decode() if error else "open failed"
+                )
+            require_equal(
+                self.api.duckdb_connect(self.database, ctypes.byref(self.connection)),
+                0,
+                "connect",
+            )
+        except BaseException:
+            self.close()
+            raise
+        finally:
+            self.api.duckdb_free(error)
+            self.api.duckdb_destroy_config(ctypes.byref(config))
+
+    def query(self, sql: str):
+        result = DuckDBResult()
+        try:
+            if self.api.duckdb_query(
+                self.connection, sql.encode(), ctypes.byref(result)
+            ):
+                raise RuntimeError(
+                    (
+                        self.api.duckdb_result_error(ctypes.byref(result))
+                        or b"query failed"
+                    ).decode()
+                )
+            rows = []
+            for row in range(self.api.duckdb_row_count(ctypes.byref(result))):
+                values = []
+                for column in range(self.api.duckdb_column_count(ctypes.byref(result))):
+                    value = self.api.duckdb_value_varchar(
+                        ctypes.byref(result), column, row
+                    )
+                    try:
+                        values.append(
+                            ctypes.string_at(value).decode() if value else None
+                        )
+                    finally:
+                        self.api.duckdb_free(value)
+                rows.append(tuple(values))
+            return rows
+        finally:
+            self.api.duckdb_destroy_result(ctypes.byref(result))
+
+    def close(self):
+        if self.connection:
+            self.api.duckdb_disconnect(ctypes.byref(self.connection))
+        if self.database:
+            self.api.duckdb_close(ctypes.byref(self.database))
+
+
+def run_clients(repository: str | None, unsigned: bool):
+    import adbc_driver_flightsql.dbapi as flightsql
+    import psycopg
+    from pyarrow import flight
+
+    password = secrets.token_urlsafe(24)
+    username = "alpha_regression"
+    with tempfile.TemporaryDirectory(prefix="duckflight-alpha-clients-") as directory:
+        root = Path(directory)
+        salt = secrets.token_bytes(16)
+        # Same PBKDF2-SHA256 verifier contract as scripts/duckflight_auth.py.
+        digest = hashlib.pbkdf2_hmac(
+            "sha256", password.encode(), salt, 10_000, dklen=32
+        ).hex()
+        config = root / "auth.toml"
+        config.write_text(
+            f'[users.{username}]\npassword_hash = "{digest}"\nsalt = {list(salt)}\niterations = 10000\n'
+        )
+        config.chmod(0o600)
+        host = Host(os.environ["DUCKDB_ALPHA_LIBRARY"], root, unsigned)
+        servers = []
+        try:
+            require_equal(
+                host.query("select current_setting('allow_unsigned_extensions')"),
+                [(str(unsigned).lower(),)],
+                "signature policy",
+            )
+            version = host.query("select version()")
+            if not version[0][0].startswith("v2.0.0"):
+                raise AssertionError(f"expected DuckDB 2.0 alpha: {version}")
+            print(f"Loading DuckFlight on {version[0][0]}", flush=True)
+            started = time.monotonic()
+            if repository:
+                host.query(
+                    f"CREATE EXTENSION REPOSITORY alpha_test WITH PREFIX {sql_literal(repository)}"
+                )
+                print(
+                    f"Repository trusted in {time.monotonic() - started:.1f}s",
+                    flush=True,
+                )
+                host.query("INSTALL duckflight FROM alpha_test")
+                print(
+                    f"Signed artifact installed in {time.monotonic() - started:.1f}s",
+                    flush=True,
+                )
+                host.query("LOAD duckflight FROM alpha_test")
+            else:
+                artifact = Path(os.environ["DUCKFLIGHT_ALPHA_EXTENSION"]).resolve(
+                    strict=True
+                )
+                host.query(f"LOAD {sql_literal(str(artifact))}")
+            print(f"Extension loaded in {time.monotonic() - started:.1f}s", flush=True)
+            require_equal(
+                host.query("select loaded, abi_version from duckflight_core_status()"),
+                [("true", "1")],
+                "real bundled core initialized",
+            )
+            print(f"PASS actual core initialized on {version[0][0]}", flush=True)
+            host.query(
+                "create table alpha_shared(id integer primary key, label varchar); insert into alpha_shared values (1, 'host')"
+            )
+            for protocol, function in [
+                ("pgwire", "duckflight_pg_serve"),
+                ("flight", "duckflight_flight_serve"),
+            ]:
+                address = host.query(
+                    f"select address from {function}('127.0.0.1:0', {sql_literal(str(config))})"
+                )[0][0]
+                servers.append((protocol, address))
+            require_equal(
+                sorted(
+                    host.query("select protocol, address from duckflight_servers()")
+                ),
+                sorted(servers),
+                "listener inventory",
+            )
+            pg_address, flight_address = servers[0][1], servers[1][1]
+            pg_host, pg_port = pg_address.rsplit(":", 1)
+            pg_options = {
+                "host": pg_host,
+                "port": int(pg_port),
+                "user": username,
+                "password": password,
+                "dbname": "duckflight",
+                "connect_timeout": 5,
+                "autocommit": True,
+            }
+            with psycopg.connect(**pg_options) as connection:
+                require_equal(
+                    connection.execute("select * from alpha_shared").fetchall(),
+                    [(1, "host")],
+                    "PgWire shared host table",
+                )
+                require_equal(
+                    connection.execute(
+                        "select initcap('hELLO wORLD'), array_remove([1,2,1],1), array_replace([1,2,1],1,3)"
+                    ).fetchone(),
+                    ("Hello World", [2], [3, 2, 3]),
+                    "PgWire compatibility macros",
+                )
+                connection.execute("begin")
+                connection.execute("insert into alpha_shared values (2, 'pgwire')")
+                connection.execute("commit")
+                connection.execute("begin")
+                connection.execute("insert into alpha_shared values (3, 'rollback')")
+                connection.execute("rollback")
+            require_equal(
+                host.query("select * from alpha_shared order by id"),
+                [("1", "host"), ("2", "pgwire")],
+                "PgWire commit and rollback",
+            )
+            try:
+                with psycopg.connect(
+                    **{**pg_options, "password": "deliberately-wrong"}
+                ):
+                    pass
+            except psycopg.OperationalError:
+                pass
+            else:
+                raise AssertionError("PgWire accepted a wrong password")
+            print(
+                "PASS PgWire authentication, shared data, macros, commit/rollback, wrong-password rejection",
+                flush=True,
+            )
+            # Exercise explicit Basic-auth handshake as well as ADBC's username/password flow.
+            with flight.FlightClient(f"grpc://{flight_address}") as client:
+                token = client.authenticate_basic_token(
+                    username, password, options=flight.FlightCallOptions(timeout=10)
+                )
+                if not token[1]:
+                    raise AssertionError(
+                        "Flight handshake did not return a bearer token"
+                    )
+            with (
+                flightsql.connect(
+                    uri=f"grpc://{flight_address}",
+                    db_kwargs={"username": username, "password": password},
+                    autocommit=True,
+                ) as connection,
+                connection.cursor() as cursor,
+            ):
+                cursor.execute("select * from alpha_shared order by id")
+                table = cursor.fetch_arrow_table()
+                require_equal(
+                    table.to_pylist(),
+                    [{"id": 1, "label": "host"}, {"id": 2, "label": "pgwire"}],
+                    "ADBC Flight SQL shared data",
+                )
+                require_equal(table.schema.names, ["id", "label"], "ADBC result schema")
+                cursor.execute(
+                    "select initcap('hELLO wORLD') as title, array_remove([1,2,1],1) as removed, array_replace([1,2,1],1,3) as replaced"
+                )
+                require_equal(
+                    cursor.fetch_arrow_table().to_pylist(),
+                    [{"title": "Hello World", "removed": [2], "replaced": [3, 2, 3]}],
+                    "Flight compatibility macros",
+                )
+                cursor.execute(
+                    "select column_name from information_schema.columns where table_name='alpha_shared' order by ordinal_position"
+                )
+                require_equal(
+                    cursor.fetchall(), [("id",), ("label",)], "Flight schema discovery"
+                )
+            print(
+                "PASS Flight Basic handshake, ADBC authenticated query, shared data, macros, schema discovery",
+                flush=True,
+            )
+        finally:
+            try:
+                for protocol, address in reversed(servers):
+                    host.query(
+                        f"select * from duckflight_stop({sql_literal(protocol)}, {sql_literal(address)})"
+                    )
+                require_equal(
+                    host.query("select * from duckflight_servers()") if servers else [],
+                    [],
+                    "all listeners stopped",
+                )
+            finally:
+                host.close()
+
+
+class AlphaDuckflightTests(unittest.TestCase):
+    def test_real_alpha_clients(self):
+        if not os.environ.get("DUCKDB_ALPHA_LIBRARY"):
+            self.skipTest(
+                "set DUCKDB_ALPHA_LIBRARY and DUCKFLIGHT_ALPHA_EXTENSION or DUCKFLIGHT_ALPHA_REPOSITORY"
+            )
+        repository = os.environ.get("DUCKFLIGHT_ALPHA_REPOSITORY")
+        command = [sys.executable, str(Path(__file__).resolve()), "--worker"]
+        if repository:
+            command.extend(["--repository", repository])
+        elif os.environ.get("DUCKFLIGHT_ALPHA_ALLOW_UNSIGNED") == "1":
+            command.append("--allow-unsigned")
+        timeout = int(os.environ.get("DUCKFLIGHT_ALPHA_TEST_TIMEOUT", "120"))
+        if timeout <= 0:
+            self.fail("DUCKFLIGHT_ALPHA_TEST_TIMEOUT must be positive")
+        try:
+            result = subprocess.run(
+                command, capture_output=True, text=True, timeout=timeout, check=False
+            )
+        except subprocess.TimeoutExpired as error:
+            self.fail(
+                f"Alpha client test exceeded {timeout} seconds.\n"
+                f"stdout: {error.stdout!r}\nstderr: {error.stderr!r}"
+            )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        print(result.stdout, end="")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repository", help="signed repository URL or local prefix")
+    parser.add_argument(
+        "--allow-unsigned",
+        action="store_true",
+        help="explicitly allow an unsigned local artifact",
+    )
+    parser.add_argument("--worker", action="store_true", help=argparse.SUPPRESS)
+    args = parser.parse_args()
+    if args.repository and args.allow_unsigned:
+        parser.error("repository tests always require signature validation")
+    if args.worker:
+        run_clients(args.repository, args.allow_unsigned)
+    else:
+        if args.repository:
+            os.environ["DUCKFLIGHT_ALPHA_REPOSITORY"] = args.repository
+        if args.allow_unsigned:
+            os.environ["DUCKFLIGHT_ALPHA_ALLOW_UNSIGNED"] = "1"
+        unittest.main(argv=[sys.argv[0]])
+
+
+if __name__ == "__main__":
+    main()

--- a/test/test_extension_repository.py
+++ b/test/test_extension_repository.py
@@ -1,0 +1,341 @@
+"""Exercise repository preparation with ephemeral keys and OpenSSL verification."""
+
+import ctypes
+import gzip
+import importlib.util
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+SPEC = importlib.util.spec_from_file_location(
+    "extension_repository",
+    Path(__file__).resolve().parents[1] / "scripts/extension_repository.py",
+)
+repository = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(repository)
+
+
+class DuckDBResult(ctypes.Structure):
+    # Public v1 duckdb.h layout; access values/errors through the C API.
+    _fields_ = [
+        ("deprecated_column_count", ctypes.c_uint64),
+        ("deprecated_row_count", ctypes.c_uint64),
+        ("deprecated_rows_changed", ctypes.c_uint64),
+        ("deprecated_columns", ctypes.c_void_p),
+        ("deprecated_error_message", ctypes.c_void_p),
+        ("internal_data", ctypes.c_void_p),
+    ]
+
+
+def extension(platform="osx_arm64", target="v2.0.0-alpha.1", abi="CPP", magic="4"):
+    fields = [magic, platform, target, "0.1.0", abi, "", "", ""]
+    footer = b"".join(field.encode().ljust(32, b"\0") for field in reversed(fields))
+    return b"\xcf\xfa\xed\xfe" + b"payload" * 180_000 + footer + bytes(256)
+
+
+class ExtensionRepositoryTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.private = repository.run(
+            [
+                "openssl",
+                "genpkey",
+                "-algorithm",
+                "RSA",
+                "-pkeyopt",
+                "rsa_keygen_bits:2048",
+            ]
+        )
+        cls.public = repository.run(["openssl", "pkey", "-pubout"], cls.private)
+        cls.other = repository.run(
+            [
+                "openssl",
+                "genpkey",
+                "-algorithm",
+                "RSA",
+                "-pkeyopt",
+                "rsa_keygen_bits:2048",
+            ]
+        )
+
+    def test_signature_matches_independent_openssl_digest_and_detects_tampering(self):
+        data = extension()
+        signed = repository.sign(data, self.private, self.public)
+        self.assertEqual(signed[:-256], data[:-256])
+        # Reference hashing uses OpenSSL, including a full chunk and a partial chunk.
+        content = data[:-256]
+        chunks = [
+            subprocess.run(
+                ["openssl", "dgst", "-sha256", "-binary"],
+                input=part,
+                capture_output=True,
+                check=True,
+            ).stdout
+            for part in [content[:1048576], content[1048576:]]
+        ]
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "chunks").write_bytes(b"".join(chunks))
+            (root / "public").write_bytes(self.public)
+            (root / "signature").write_bytes(signed[-256:])
+            result = subprocess.run(
+                [
+                    "openssl",
+                    "dgst",
+                    "-sha256",
+                    "-verify",
+                    str(root / "public"),
+                    "-signature",
+                    str(root / "signature"),
+                    str(root / "chunks"),
+                ],
+                capture_output=True,
+                check=False,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+        with self.assertRaises(ValueError):
+            repository.verify(bytes([signed[0] ^ 1]) + signed[1:], self.public)
+        with self.assertRaises(ValueError):
+            repository.verify(signed[:-1] + bytes([signed[-1] ^ 1]), self.public)
+
+    def test_rejects_wrong_key_and_existing_signature(self):
+        with self.assertRaisesRegex(ValueError, "does not match"):
+            repository.sign(extension(), self.other, self.public)
+        with self.assertRaisesRegex(ValueError, "existing signature"):
+            repository.sign(extension()[:-1] + b"x", self.private, self.public)
+
+    def test_metadata_and_path_validation(self):
+        for data, version in [
+            (b"short", "v2.0.0"),
+            (extension(magic="3"), "v2.0.0-alpha.1"),
+            (extension(platform="../escape"), "v2.0.0-alpha.1"),
+            (extension(), "../escape"),
+            (extension(), "v1.5.5"),
+            (extension(abi="C_STRUCT_UNSTABLE"), "v1.5.5"),
+            (extension(abi="invalid"), "v2.0.0-alpha.1"),
+            (extension(abi="C_STRUCT", target="garbage"), "v2.0.0-alpha.1"),
+            (extension(platform="osx\0arm64"), "v2.0.0-alpha.1"),
+        ]:
+            with (
+                self.subTest(version=version, footer=data[-512:-256]),
+                self.assertRaises(ValueError),
+            ):
+                repository.metadata(data, version)
+        self.assertEqual(
+            repository.metadata(
+                extension(abi="C_STRUCT", target="v1.2.0"), "v2.0.0-alpha.1"
+            ),
+            "osx_arm64",
+        )
+
+    def test_prepare_preserves_footer_and_is_deterministic(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            artifact = root / "duckflight.duckdb_extension"
+            artifact.write_bytes(extension())
+            public_metadata = root / "metadata.json"
+            public_metadata.write_text(
+                json.dumps({"signature_keys": [self.public.decode()]})
+            )
+            original_run = repository.run
+
+            def run(arguments, data=None):
+                if arguments[0] == "op":
+                    self.assertEqual(arguments, ["op", "read", repository.DEFAULT_KEY])
+                    return self.private
+                return original_run(arguments, data)
+
+            with patch.object(repository, "run", side_effect=run):
+                first = repository.prepare(
+                    artifact, root / "first", "v2.0.0-alpha.1", public_metadata
+                )
+                second = repository.prepare(
+                    artifact, root / "second", "v2.0.0-alpha.1", public_metadata
+                )
+                with self.assertRaises(FileExistsError):
+                    repository.prepare(
+                        artifact, root / "first", "v2.0.0-alpha.1", public_metadata
+                    )
+            self.assertEqual(
+                first.relative_to(root / "first").as_posix(),
+                "v2.0.0-alpha.1/osx_arm64/duckflight.duckdb_extension.gz",
+            )
+            self.assertEqual(first.read_bytes(), second.read_bytes())
+            signed = gzip.decompress(first.read_bytes())
+            self.assertEqual(signed[:-256], artifact.read_bytes()[:-256])
+            repository.verify(signed, self.public)
+            self.assertFalse(
+                any(
+                    self.private in path.read_bytes()
+                    for path in root.rglob("*")
+                    if path.is_file()
+                )
+            )
+
+    def test_optional_alpha_runtime_accepts_signed_fixture_and_rejects_tampering(self):
+        library = os.environ.get("DUCKDB_ALPHA_LIBRARY")
+        if not library or not Path(library).is_file() or not shutil.which("cc"):
+            self.skipTest(
+                "set DUCKDB_ALPHA_LIBRARY to an alpha shared library and install cc"
+            )
+        api = ctypes.CDLL(library)
+        pointer = ctypes.c_void_p
+        signatures = {
+            "duckdb_create_config": ([ctypes.POINTER(pointer)], ctypes.c_int),
+            "duckdb_set_config": (
+                [pointer, ctypes.c_char_p, ctypes.c_char_p],
+                ctypes.c_int,
+            ),
+            "duckdb_destroy_config": ([ctypes.POINTER(pointer)], None),
+            "duckdb_open_ext": (
+                [
+                    ctypes.c_char_p,
+                    ctypes.POINTER(pointer),
+                    pointer,
+                    ctypes.POINTER(pointer),
+                ],
+                ctypes.c_int,
+            ),
+            "duckdb_close": ([ctypes.POINTER(pointer)], None),
+            "duckdb_connect": ([pointer, ctypes.POINTER(pointer)], ctypes.c_int),
+            "duckdb_disconnect": ([ctypes.POINTER(pointer)], None),
+            "duckdb_query": (
+                [pointer, ctypes.c_char_p, ctypes.POINTER(DuckDBResult)],
+                ctypes.c_int,
+            ),
+            "duckdb_destroy_result": ([ctypes.POINTER(DuckDBResult)], None),
+            "duckdb_result_error": ([ctypes.POINTER(DuckDBResult)], ctypes.c_char_p),
+            "duckdb_value_varchar": (
+                [ctypes.POINTER(DuckDBResult), ctypes.c_uint64, ctypes.c_uint64],
+                pointer,
+            ),
+            "duckdb_free": ([pointer], None),
+        }
+        for name, (arguments, result) in signatures.items():
+            getattr(api, name).argtypes = arguments
+            getattr(api, name).restype = result
+
+        connection = pointer()
+        database = pointer()
+
+        def query(sql, expect_error=False):
+            result = DuckDBResult()
+            try:
+                status = api.duckdb_query(
+                    connection, sql.encode(), ctypes.byref(result)
+                )
+                error = (api.duckdb_result_error(ctypes.byref(result)) or b"").decode()
+                if expect_error:
+                    self.assertNotEqual(status, 0, sql)
+                    self.assertIn("signature", error.lower())
+                    return None
+                self.assertEqual(status, 0, error)
+                value = api.duckdb_value_varchar(ctypes.byref(result), 0, 0)
+                try:
+                    return ctypes.string_at(value).decode() if value else None
+                finally:
+                    api.duckdb_free(value)
+            finally:
+                api.duckdb_destroy_result(ctypes.byref(result))
+
+        with tempfile.TemporaryDirectory(prefix="duckflight-runtime-") as directory:
+            root = Path(directory)
+
+            def open_database():
+                config = pointer()
+                error = pointer()
+                self.assertEqual(api.duckdb_create_config(ctypes.byref(config)), 0)
+                try:
+                    for name, value in {
+                        "extension_repository_directory": str(root / "trust"),
+                        "extension_directories": f"['{root / 'installed'}']",
+                        "allow_unsigned_extensions": "false",
+                        "allow_extension_repositories": "allowed",
+                    }.items():
+                        self.assertEqual(
+                            api.duckdb_set_config(
+                                config, name.encode(), value.encode()
+                            ),
+                            0,
+                            name,
+                        )
+                    status = api.duckdb_open_ext(
+                        None, ctypes.byref(database), config, ctypes.byref(error)
+                    )
+                    self.assertEqual(
+                        status,
+                        0,
+                        ctypes.string_at(error).decode() if error else "open failed",
+                    )
+                    self.assertEqual(
+                        api.duckdb_connect(database, ctypes.byref(connection)), 0
+                    )
+                    self.assertEqual(
+                        query("select current_setting('allow_unsigned_extensions')"),
+                        "false",
+                    )
+                finally:
+                    api.duckdb_free(error)
+                    api.duckdb_destroy_config(ctypes.byref(config))
+
+            try:
+                open_database()
+                platform = query("pragma platform")
+                version = query("select library_version from pragma_version()")
+                if "dev" in version:
+                    version = query("select source_id from pragma_version()")
+                source = root / "fixture.c"
+                # This is a native no-op test fixture, NOT the real DuckFlight core.
+                source.write_text(
+                    "#include <stdbool.h>\nbool duckflight_init_c_api(void *info, void *access) { return true; }\n"
+                )
+                artifact = root / "duckflight.duckdb_extension"
+                subprocess.run(
+                    ["cc", "-shared", "-fPIC", str(source), "-o", str(artifact)],
+                    capture_output=True,
+                    check=True,
+                    timeout=30,
+                )
+                fields = ["4", platform, "v1.5.6", "test", "C_STRUCT", "", "", ""]
+                footer = b"".join(
+                    field.encode().ljust(32, b"\0") for field in reversed(fields)
+                )
+                unsigned = artifact.read_bytes() + footer + bytes(256)
+                repository.metadata(unsigned, version)
+                signed = repository.sign(unsigned, self.private, self.public)
+                served = root / "repository"
+                metadata_path = served / ".well-known/duckdb-extension-repo.json"
+                metadata_path.parent.mkdir(parents=True)
+                metadata_path.write_text(
+                    json.dumps({"signature_keys": [self.public.decode()]})
+                )
+                download = (
+                    served / version / platform / "duckflight.duckdb_extension.gz"
+                )
+                download.parent.mkdir(parents=True)
+                download.write_bytes(gzip.compress(signed, mtime=0))
+                query(f"CREATE EXTENSION REPOSITORY fixture WITH PREFIX '{served}'")
+                query("INSTALL duckflight FROM fixture")
+                query("LOAD duckflight FROM fixture")
+                api.duckdb_disconnect(ctypes.byref(connection))
+                api.duckdb_close(ctypes.byref(database))
+                open_database()
+                query("LOAD duckflight FROM fixture")
+                download.write_bytes(
+                    gzip.compress(signed[:-1] + bytes([signed[-1] ^ 1]), mtime=0)
+                )
+                query("FORCE INSTALL duckflight FROM fixture", expect_error=True)
+            finally:
+                if connection:
+                    api.duckdb_disconnect(ctypes.byref(connection))
+                if database:
+                    api.duckdb_close(ctypes.byref(database))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds a local signing utility and public-key metadata for the independently signed repository at https://extensions.sidequery.dev. The utility reads the RSA key from 1Password into memory, checks it against the repository public key, signs and verifies the extension without changing its ABI metadata, and writes deterministic gzip output. It rejects invalid paths, existing signatures, and existing output files.

Includes installation/release documentation, signer tests wired into CI, and an optional native alpha client test covering actual core initialization, authenticated PostgreSQL and Flight SQL queries, shared data, macros, transactions, and listener cleanup.

The repository is already deployed on R2 for macOS arm64. Fresh HTTPS installation with unsigned extensions disabled passed on DuckDB alpha41489. Alpha41533 passed signed local installation and client checks; its official httpfs deployment was still pending during validation.

Validation: five signing tests pass against the actual alpha engine, including persisted trust and tamper rejection; Ruff lint/format and diff checks pass. The rebuilt bundled extension passed real PostgreSQL and Flight SQL client checks on both alpha runtimes. Existing stable distribution is unchanged; no private signing key or core source is included.
